### PR TITLE
Add dependabot version and security support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: "mix"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      elixir:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      elixir_major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
+  - package-ecosystem: "cargo"
+    directory: "/native/silicon_nif"
+    schedule:
+      interval: "monthly"
+    groups:
+      rust:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      rust_major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
Keeping dependencies up-to-date helps prevent code rot and security vulnerabilities from cropping up - so it's probably a good idea to leverage Githubs Dependabot to track dependency versions and if they have any related security advisories.

### Dependabot Version Updates
Have created an initial `dependabot.yml` file for implementing Dependabots version updates. I have taken the liberty to configure Dependabots PR grouping policy to split the PRs for each environment (`mix`, `cargo`) based on the version updates 'complexity'. `minor` and `patch` updates are one group as assuming correctly implemented semversioning major breaking changes should not be introduced at this level and they should be relatively straightforward to accomodate. `major` updates are the other group, as semversioning dictates major updates may introduce large incompatible changes and may require extensive work to accomodate.

Furthermore a 'monthly' interval is chosen for Dependabot checks to prevent excessive noise and churn for versioning updates.

### Dependabot Security Updates
The Github documentation "Configuration options for the dependabot.yml file" for `groups` configuration option (https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) states:
` You can only use the dependabot.yml file to create groups for Dependabot version updates. Grouped Dependabot security updates are enabled or disabled in your repository or organization settings and do not support customization. `

As it is not possible to enable/disable Dependabot Security Updates and their grouping from the `dependabot.yml` configuration file I leave the appropriate documentation links here for enabling them.

*Enabling repo level Dependabot Security Updates*
https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#enabling-or-disabling-dependabot-security-updates-for-an-individual-repository

*Grouping repo level Dependabot Security Updates*
https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#enabling-or-disabling-grouped-dependabot-security-updates-for-an-individual-repository