### PR TITLE
Load precompiled NIF from environment variable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+_build
+deps
+.elixir-tools
+.gitignore
+.github
+priv
+erl_crash.dump

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,5 @@ deps
 .github
 .git
 priv
-erl_crash.dump
+**/erl_crash.dump
 native/**/target

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,7 @@ deps
 .elixir-tools
 .gitignore
 .github
+.git
 priv
 erl_crash.dump
+native/**/target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+
+# TODO: Leverage Cargo Chef for Rust to improve dependency caching for Rust.
+# TODO: Add support for building DEV or PROD environment images.
+
+ARG ALPINE_VERSION=3.18
+ARG ALPINE_PATCH_VER=4
+
+ARG RUST_VERSION=1.75.0
+ARG ELIXIR_VERSION=1.16.0
+ARG OTP_VERSION=26.2.1
+
+ARG RUST_BUILDER="rust:${RUST_VERSION}-alpine${ALPINE_VERSION}"
+ARG ELIXIR_BUILDER="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-alpine-${ALPINE_VERSION}.${ALPINE_PATCH_VER}"
+ARG RUNNER_IMAGE="alpine:${ALPINE_VERSION}"
+
+########
+# Rust Builder
+########
+FROM ${RUST_BUILDER} as nif
+WORKDIR /usr/src/silicon_nif
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+RUN apk add --no-cache fontconfig-dev \
+g++ \
+python3 \
+pkgconfig \
+harfbuzz-dev \
+musl-dev;
+COPY ./native/silicon_nif/ .
+ENV CARGO_TARGET_DIR=build
+RUN cargo build --release
+
+########
+# Elixir Builder
+########
+FROM ${ELIXIR_BUILDER} AS elixir
+WORKDIR /usr/bin/silicon
+ENV NIF_LOAD_PATH=priv/libsilicon_nif
+COPY --from=nif /usr/src/silicon_nif/build/release/libsilicon_nif.so priv/libsilicon_nif.so
+RUN mix local.hex --force
+COPY mix.exs mix.lock .
+RUN mix do deps.get, deps.compile
+COPY . .
+RUN mix release --path release
+
+########
+# Runner
+########
+FROM ${RUNNER_IMAGE}
+WORKDIR /usr/bin/silicon
+COPY --from=elixir /usr/bin/silicon/release .
+
+RUN apk upgrade --no-cache & apk add --no-cache \
+  harfbuzz-dev;
+
+CMD ["bin/silicon", "start"]

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,9 +1,9 @@
 import Config
 
 if nif_path = System.get_env("NIF_LOAD_PATH") do
-   config :silicon, Silicon.Native,
-     load_from: {:silicon, nif_path},
-     skip_compilation?: true
+  config :silicon, Silicon.Native,
+    load_from: {:silicon, nif_path},
+    skip_compilation?: true
 end
 
 env_conf = "#{config_env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,14 +1,10 @@
 import Config
 
-case System.get_env("NIF_LOAD_PATH") do
-  nif_path when not is_nil(nif_path) and is_bitstring(nif_path) ->
-    config :silicon, Silicon.Native,
-      load_from: {:silicon, nif_path},
-      skip_compilation?: true
-
-  nil -> true # Keep default Rustler behaviour
+if nif_path = System.get_env("NIF_LOAD_PATH") do
+   config :silicon, Silicon.Native,
+     load_from: {:silicon, nif_path},
+     skip_compilation?: true
 end
-
 
 env_conf = "#{config_env()}.exs"
 if File.exists?(env_conf), do: import_config(env_conf)

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,9 +6,7 @@ case System.get_env("NIF_LOAD_PATH") do
       load_from: {:silicon, nif_path},
       skip_compilation?: true
 
-  nil ->
-    config :silicon, Silicon.Native,
-      skip_compilation?: false
+  nil -> true # Keep default Rustler behaviour
 end
 
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,16 @@
+import Config
+
+case System.get_env("NIF_LOAD_PATH") do
+  nif_path when not is_nil(nif_path) and is_bitstring(nif_path) ->
+    config :silicon, Silicon.Native,
+      load_from: {:silicon, nif_path},
+      skip_compilation?: true
+
+  nil ->
+    config :silicon, Silicon.Native,
+      skip_compilation?: false
+end
+
+
+env_conf = "#{config_env()}.exs"
+if File.exists?(env_conf), do: import_config(env_conf)

--- a/lib/native.ex
+++ b/lib/native.ex
@@ -1,13 +1,11 @@
-#  This Source Code Form is subject to the terms of the Mozilla Public
-#  License, v. 2.0. If a copy of the MPL was not distributed with this
-#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-defmodule Elixir.Silicon.Native do
+defmodule Silicon.Native do
   @moduledoc """
   Don't use the functions prefixed with `nif_`. The error messages for input validation are bad to misleading.
   """
 
-  use Rustler, otp_app: :silicon, crate: "silicon_nif"
+  use Rustler,
+    otp_app: :silicon,
+    crate: "silicon_nif"
   use TypeCheck
 
   @type! rustler_error :: any()

--- a/lib/native.ex
+++ b/lib/native.ex
@@ -6,6 +6,7 @@ defmodule Silicon.Native do
   use Rustler,
     otp_app: :silicon,
     crate: "silicon_nif"
+
   use TypeCheck
 
   @type! rustler_error :: any()


### PR DESCRIPTION
Support loading a precompiled NIF from an environment variable and skip compiling NIF if provided. This feature would allow seperating the Elixir and Rust build environment which is useful when dealing with multi-stage Dockerfiles as well as in CI.

Implemented leveraging Rustlers `load_from` and `skip_compilation?` if the environment variable `NIF_LOAD_PATH` is set when building the library. This should have no affect on end-users of the library themselves as far as I know because `config/*.exs` files are not evaluated when the library is used as a dependency.

Documentation for `load_from` and `skip_compilation?`: https://hexdocs.pm/rustler/Rustler.html