### PR TITLE
Implement a Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+_build
+deps
+.elixir-tools
+.gitignore
+.github
+priv
+erl_crash.dump

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,5 @@ deps
 .github
 .git
 priv
-erl_crash.dump
+**/erl_crash.dump
 native/**/target

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,7 @@ deps
 .elixir-tools
 .gitignore
 .github
+.git
 priv
 erl_crash.dump
+native/**/target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+
+# TODO: Leverage Cargo Chef for Rust to improve dependency caching for Rust.
+# TODO: Add support for building DEV or PROD environment images.
+
+ARG ALPINE_VERSION=3.18
+ARG ALPINE_PATCH_VER=4
+
+ARG RUST_VERSION=1.75.0
+ARG ELIXIR_VERSION=1.16.0
+ARG OTP_VERSION=26.2.1
+
+ARG RUST_BUILDER="rust:${RUST_VERSION}-alpine${ALPINE_VERSION}"
+ARG ELIXIR_BUILDER="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-alpine-${ALPINE_VERSION}.${ALPINE_PATCH_VER}"
+ARG RUNNER_IMAGE="alpine:${ALPINE_VERSION}"
+
+########
+# Rust Builder
+########
+FROM ${RUST_BUILDER} as nif
+WORKDIR /usr/src/silicon_nif
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+RUN apk add --no-cache fontconfig-dev \
+g++ \
+python3 \
+pkgconfig \
+harfbuzz-dev \
+musl-dev;
+COPY ./native/silicon_nif/ .
+ENV CARGO_TARGET_DIR=build
+RUN cargo build --release
+
+########
+# Elixir Builder
+########
+FROM ${ELIXIR_BUILDER} AS elixir
+WORKDIR /usr/bin/silicon
+ENV NIF_LOAD_PATH=priv/libsilicon_nif
+COPY --from=nif /usr/src/silicon_nif/build/release/libsilicon_nif.so priv/libsilicon_nif.so
+RUN mix local.hex --force
+COPY mix.exs mix.lock .
+RUN mix do deps.get, deps.compile
+COPY . .
+RUN mix release --path release
+
+########
+# Runner
+########
+FROM ${RUNNER_IMAGE}
+WORKDIR /usr/bin/silicon
+COPY --from=elixir /usr/bin/silicon/release .
+
+RUN apk upgrade --no-cache & apk add --no-cache \
+  harfbuzz-dev;
+
+CMD ["bin/silicon", "start"]


### PR DESCRIPTION
Implementing a `Dockerfile` is convenient for developers and end-users looking to deploy into containerized environment. Furthermore this should help track what is required in terms or system dependencies for successfully compiling the native Rust NIF, as well as the necessary runtime dependencies. This becomes especially useful since Rust may compile the NIF successfully but still fail during runtime - which leads to needing to guesstimate what exactly is missing from erl crash dumps.

In particular, it seems that the native `silicon` crate depends on Harfbuzz at a feature level - which translates to it compiling succesfully even if Harfbuzz dependency is unavailable during compilation phase, but crashing during runtime when attempting to run the `silicion.ex` library.

 Note - this `Dockerfile` may not be suitable *as is* for an end-user looking to deploy the library as it is simply a **minimal** example of requirements for building and running. User may wish to use this `Dockerfile` as a starting point and add in necessary runtime packages for their use case, such as `firacode` or other particular fonts, or use updated images for Elixir, Rust or Alpine. It may also be desirable for the end-user to configure the enviroments locale through `LOCALE`, `LANGUAGE`, `LC_ALL`, and `locale-gen`.